### PR TITLE
Working events

### DIFF
--- a/contexts/Web3Context.tsx
+++ b/contexts/Web3Context.tsx
@@ -40,6 +40,33 @@ export const Web3Provider = ({ children }: Web3ProviderProps) => {
           YesNoVoting.abi,
           deployedNetwork && deployedNetwork.address
         );
+        const web3test = new Web3(new Web3.providers.WebsocketProvider('ws://127.0.0.1:8545'));
+        const instance1 = new web3test.eth.Contract(
+          YesNoVoting.abi,
+          deployedNetwork && deployedNetwork.address
+        );
+        instance1.events.VotingStarted().on('data', () => {
+          notifications.show({
+            title: 'Voting started',
+            message: 'Voting has started!',
+            color: 'blue',
+          });
+        });
+        instance1.events.VotingEnded().on('data', () => {
+          notifications.show({
+            title: 'Voting ended',
+            message: 'Voting has ended!',
+            color: 'blue',
+          });
+        });
+        instance1.events.VoteSubmitted().on('data', (eventData: any) => {
+          console.log('Vote submitted', eventData);
+          notifications.show({
+            title: 'Vote submitted',
+            message: 'Voting has ended!',
+            color: 'blue',
+          });
+        });
         setWeb3(web3Instance);
         setAccounts(ethAccounts);
         setContract(instance);

--- a/contracts/YesNoVoting.json
+++ b/contracts/YesNoVoting.json
@@ -12907,12 +12907,12 @@
     "1720004530745": {
       "events": {},
       "links": {},
-      "address": "0xF9e1371eD9aeEEB360fB7C7e773a79754f9d3E1F",
-      "transactionHash": "0x6d63b87da2de888218d2f823e5a05f971c3e7e2e9681ec9e1c6c8b73638a40b3"
+      "address": "0x1748eEF6F9dda8924CE528c7f4d3898ceE7ec7F7",
+      "transactionHash": "0x72ac639bc08fe6d6cff2aa5747a0d4f0c6cf02272feaf1c05fc0ec50a3ffc547"
     }
   },
   "schemaVersion": "3.4.16",
-  "updatedAt": "2024-07-03T11:02:21.942Z",
+  "updatedAt": "2024-07-03T12:15:30.419Z",
   "networkType": "ethereum",
   "devdoc": {
     "kind": "dev",

--- a/contracts/YesNoVoting.json
+++ b/contracts/YesNoVoting.json
@@ -12907,12 +12907,12 @@
     "1720004530745": {
       "events": {},
       "links": {},
-      "address": "0x1748eEF6F9dda8924CE528c7f4d3898ceE7ec7F7",
-      "transactionHash": "0x72ac639bc08fe6d6cff2aa5747a0d4f0c6cf02272feaf1c05fc0ec50a3ffc547"
+      "address": "0xfADE7D4613C31AFDb387DAC35Ffa71e12ea923C5",
+      "transactionHash": "0xe97c7148137493acfefdd4b84e50b8adbb0c751b24a38225ee01ce07fc4cb086"
     }
   },
   "schemaVersion": "3.4.16",
-  "updatedAt": "2024-07-03T12:15:30.419Z",
+  "updatedAt": "2024-07-03T12:22:02.048Z",
   "networkType": "ethereum",
   "devdoc": {
     "kind": "dev",

--- a/hooks/useSubmitVote.ts
+++ b/hooks/useSubmitVote.ts
@@ -1,0 +1,39 @@
+import { useState, useCallback } from 'react';
+import { notifications } from '@mantine/notifications';
+import { useWeb3 } from '@/contexts/Web3Context';
+
+export const useSubmitVote = () => {
+  const { contract, accounts } = useWeb3();
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const submitVote = useCallback(
+    async (candidateId: number, vote: boolean) => {
+      if (!contract || !accounts || accounts.length === 0) return;
+
+      setLoading(true);
+      try {
+        await contract.methods
+          .vote(candidateId, vote)
+          .send({ from: accounts[0], gas: '1000000', gasPrice: 1000000000 });
+        notifications.show({
+          title: 'Vote Submitted',
+          message: 'Your vote has been submitted successfully',
+          color: 'green',
+        });
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Error submitting vote:', error);
+        notifications.show({
+          title: 'Vote Submission Failed',
+          message: `Failed to submit vote: ${error.message}`,
+          color: 'red',
+        });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [contract, accounts]
+  );
+
+  return { submitVote, loading };
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "prettier:write": "prettier --write \"**/*.{ts,tsx}\"",
     "test": "npm run prettier:check && npm run lint && npm run typecheck && npm run jest",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build"
+    "storybook:build": "storybook build",
+    "migrate": "cd ../btda-self-tallying-election && truffle migrate && cp ../btda-self-tallying-election/build/contracts/YesNoVoting.json ../btda-self-tallying-election-ui/contracts",
+    "ganache": "ganache-cli"
   },
   "dependencies": {
     "@mantine/core": "7.11.1",

--- a/pages/voter/index.tsx
+++ b/pages/voter/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Container, Title } from '@mantine/core';
+import { Button, Container, Title } from '@mantine/core';
+import { useSubmitVote } from '@/hooks/useSubmitVote';
 
 const VoterPage = () => {
   //   useEffect(() => {
@@ -7,11 +8,18 @@ const VoterPage = () => {
   //   });
   // eslint-disable-next-line no-console
   console.log('VoterPage');
+  const { submitVote, loading } = useSubmitVote();
+  const handleVote = (candidateId: number, vote: boolean) => {
+    submitVote(candidateId, vote);
+  };
   return (
     <Container>
       <Title order={2} my="lg">
         Voter Page
       </Title>
+      <Button type="button" onClick={() => handleVote(1, true)}>
+        Vote Yes
+      </Button>
     </Container>
   );
 };


### PR DESCRIPTION
- Capture and handle events from contract
- Added `npm run migrate` script to make contract re-depolyment easier (btda-self-tallying-election repo has to be at the same level as this one)
- Also added `npm run ganache` cuz why not